### PR TITLE
Fixed inaccurate count of port connections.

### DIFF
--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -165,10 +165,10 @@ if [ ! -z "$ConnectionPorts" ]
 then
 	IFS=',' read -r -a ConnectionPortsArray <<< "$ConnectionPorts"
 	declare -A Connections
-	netstat=$(netstat -ntu)
+	netstat=$(netstat -ntu | awk '{print $4}')
 	for cPort in "${ConnectionPortsArray[@]}"
 	do
-		Connections[$cPort]=$(echo "$netstat" | grep -w "$cPort" | wc -l)
+		Connections[$cPort]=$(echo "$netstat" | grep ":$cPort$" | wc -l)
 	done
 fi
 
@@ -231,10 +231,10 @@ do
 	# Port connections
 	if [ ! -z "$ConnectionPorts" ]
 	then
-		netstat=$(netstat -ntu)
+		netstat=$(netstat -ntu | awk '{print $4}')
 		for cPort in "${ConnectionPortsArray[@]}"
 		do
-			Connections[$cPort]=$(echo | awk "{ print ${Connections[$cPort]} + $(echo "$netstat" | grep -w "$cPort" | wc -l) }")
+			Connections[$cPort]=$(echo | awk "{ print ${Connections[$cPort]} + $(echo "$netstat" | grep ":$cPort$" | wc -l) }")
 		done
 	fi
 	# Check if minute changed, so we can end the loop


### PR DESCRIPTION
`netstat -ntu` prints more than one columns and port number is then matched against all of them. I believe that wasn't intended. Also, low port numbers could be part of IP address, so more specific match including `:` needs to be in place.