### PR TITLE
Change from netstat to ss for better compatibility

### DIFF
--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -165,10 +165,10 @@ if [ ! -z "$ConnectionPorts" ]
 then
 	IFS=',' read -r -a ConnectionPortsArray <<< "$ConnectionPorts"
 	declare -A Connections
-	netstat=$(netstat -ntu | awk '{print $4}')
+	ss=$(ss -ntu | awk '{print $5}')
 	for cPort in "${ConnectionPortsArray[@]}"
 	do
-		Connections[$cPort]=$(echo "$netstat" | grep ":$cPort$" | wc -l)
+		Connections[$cPort]=$(echo "$ss" | grep ":$cPort$" | wc -l)
 	done
 fi
 
@@ -231,10 +231,10 @@ do
 	# Port connections
 	if [ ! -z "$ConnectionPorts" ]
 	then
-		netstat=$(netstat -ntu | awk '{print $4}')
+		ss=$(ss -ntu | awk '{print $5}')
 		for cPort in "${ConnectionPortsArray[@]}"
 		do
-			Connections[$cPort]=$(echo | awk "{ print ${Connections[$cPort]} + $(echo "$netstat" | grep ":$cPort$" | wc -l) }")
+			Connections[$cPort]=$(echo | awk "{ print ${Connections[$cPort]} + $(echo "$ss" | grep ":$cPort$" | wc -l) }")
 		done
 	fi
 	# Check if minute changed, so we can end the loop


### PR DESCRIPTION
There are some distros, such as Arch Linux, where netstat has been deprecated and is no longer available by default. ss is a widely used alternative and installed by default (comes with iproute at least on Arch, Debian and RHEL — seems ubiquitous, but should probably be tested more).

Even when netstat is available, ss works, so it seems there's no need to detect which one to use — ss alone should suffice.

Here's the archlinux.org notice: [Deprecation of net-tools](https://www.archlinux.org/news/deprecation-of-net-tools/)