### PR TITLE
Fix disk IO data collection for LVM setups (and possibly others)

### DIFF
--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -190,6 +190,12 @@ do
 done
 declare -A IOPSRead
 declare -A IOPSWrite
+for i in "${!vDISKs[@]}"
+do
+	IOPSRead[$i]=$(echo "$diskstats" | grep -w "${vDISKs[$i]}" | awk '{print $6}')
+	IOPSWrite[$i]=$(echo "$diskstats" | grep -w "${vDISKs[$i]}" | awk '{print $10}')
+done
+
 # Collect data loop
 for X in $(seq $RunTimes)
 do

--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -183,19 +183,13 @@ fi
 
 # Disks IOPS
 declare -A vDISKs
+diskstats=$(cat /proc/diskstats)
 for i in $(df | awk '$1 ~ /\// {print}' | awk '{print $(NF)}')
 do
-	vDISKs[$i]=$(lsblk -l | grep -w "$i" | awk '{print $1}')
+	vDISKs[$i]=$(echo "$diskstats" | grep -w "$(lsblk -l | grep -w "$i" | sed -E 's/.* ([0-9]+):([0-9]+).*/\1 *\2/')" |awk '{print $3}')
 done
 declare -A IOPSRead
 declare -A IOPSWrite
-diskstats=$(cat /proc/diskstats)
-for i in "${!vDISKs[@]}"
-do
-	IOPSRead[$i]=$(echo "$diskstats" | grep -w "${vDISKs[$i]}" | awk '{print $6}')
-	IOPSWrite[$i]=$(echo "$diskstats" | grep -w "${vDISKs[$i]}" | awk '{print $10}')
-done
-
 # Collect data loop
 for X in $(seq $RunTimes)
 do


### PR DESCRIPTION
The collection of disk IO stats doesn't work for my LVM setup:
```
root@nl:~# lsblk -l
NAME     MAJ:MIN RM  SIZE RO TYPE  MOUNTPOINTS
sr0       11:0    1  368K  0 rom   
vda      252:0    0  4.5T  0 disk  
vda1     252:1    0    1M  0 part  
vda2     252:2    0  4.5T  0 part  
luks     253:0    0  4.5T  0 crypt 
vg0-root 253:1    0   50G  0 lvm   /
vg0-swap 253:2    0    4G  0 lvm   [SWAP]
vg0-home 253:3    0  4.5T  0 lvm   /home
```
```
root@nl:~# cat /proc/diskstats 
   7       0 loop0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   7       1 loop1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   7       2 loop2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   7       3 loop3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   7       4 loop4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   7       5 loop5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   7       6 loop6 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   7       7 loop7 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
  11       0 sr0 53 0 350 21 0 0 0 0 0 60 21 0 0 0 0 0 0
 252       0 vda 127738 6092 24792808 1318834 2440750 573137 67967912 3800408 0 1821416 5188906 0 0 0 0 168084 69664
 252       1 vda1 84 0 658 160 0 0 0 0 0 200 160 0 0 0 0 0 0
 252       2 vda2 127525 6092 24786751 1317794 2440750 573137 67967912 3800408 0 1820992 5118202 0 0 0 0 0 0
 253       0 dm-0 133551 0 24784964 1431684 2989115 0 67967912 11160832 0 1866872 12592516 0 0 0 0 0 0
 253       1 dm-1 33008 0 2346606 261696 2863983 0 28326984 10457368 0 1508368 10719064 0 0 0 0 0 0
 253       2 dm-2 452 0 12604 2268 1830 0 14640 7752 0 3244 10020 0 0 0 0 0 0
 253       3 dm-3 100018 0 22423214 1167836 110453 0 39626288 341248 0 378516 1509084 0 0 0 0 0 0
```
So basically, e.g. for `/home` it was looking for `vg0-home` in `/proc/diskstats` but that only has the `dm-[0-3]` entries. The modified version uses the major:minor to translate into the device-mapper entires via `/etc/partitions`. This should also work with non-LVM setups.

It also removes unnecessary `IOPSRead` and `IOPSWrite` in the initialization as this is repeated later in the loop
