### PR TITLE
Make timeout send SIGKILL when running needs-restarting in RedHat-based installations

### DIFF
--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -292,7 +292,7 @@ elif [ -f /etc/redhat-release ]
 then
 	OS=$(cat /etc/redhat-release)
 	# Check if system requires reboot (Only supported in CentOS/RHEL 7 and later, with yum-utils installed)
-	if timeout 5 needs-restarting -r | grep -q 'Reboot is required'
+	if timeout -s 9 5 needs-restarting -r | grep -q 'Reboot is required'
 	then
 		RequiresReboot=1
 	fi


### PR DESCRIPTION
In *some* very rare circumstances, `needs-restarting` can hang in a way that's not caught by `timeout` by default, which results in the agent script hanging indefinitely. By setting the signal to 9/SIGKILL, the process gets terminated and the script can finish running.

In my case, `needs-restarting` in a CloudLinux box tries to phone an IP address that's currently offline. This made the entire script fail to send the data to HetrixTools. Specifying the signal fixed the issue.