### PR TITLE
Replace ifconfig with ip command for IP address extraction

### DIFF
--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -479,7 +479,7 @@ do
 	NICS="$NICS$NIC,$RX,$TX;"
 	# Individual NIC IP addresses
 	IPv4="$IPv4$NIC,$(ip -4 addr show "$NIC" | grep -oP 'inet \K[\d.]+' | xargs | sed 's/ /,/g')"
-	IPv6="$IPv6$NIC,$(ip -6 addr show "$NIC" | grep -oP 'inet6 \K[0-9a-fA-F:]+' | xargs | sed 's/ /,/g')"
+	IPv6="$IPv6$NIC,$(ip -6 addr show "ens3" | grep -oP 'inet6 .* scope global' | awk '{print $2}' | xargs | sed 's/ /,/g')"
 done
 NICS=$(echo -ne "$NICS" | base64 | xargs | sed 's/ //g')
 IPv4=$(echo -ne "$IPv4" | base64 | xargs | sed 's/ //g')

--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -478,8 +478,8 @@ do
 	TX=$(echo "$TX" | awk '{printf "%18.0f",$1}' | xargs)
 	NICS="$NICS$NIC,$RX,$TX;"
 	# Individual NIC IP addresses
-	IPv4="$IPv4$NIC,$(ifconfig "$NIC" | grep -w 'inet' | awk '{print $2}' | xargs | sed 's/ /,/g');"
-	IPv6="$IPv6$NIC,$(ifconfig "$NIC" | grep -w 'inet6' | grep -w 'global' | awk '{print $2}' | xargs | sed 's/ /,/g');"
+	IPv4="$IPv4$NIC,$(ip -4 addr show "$NIC" | grep -oP 'inet \K[\d.]+' | xargs | sed 's/ /,/g')"
+	IPv6="$IPv6$NIC,$(ip -6 addr show "$NIC" | grep -oP 'inet6 \K[0-9a-fA-F:]+' | xargs | sed 's/ /,/g')"
 done
 NICS=$(echo -ne "$NICS" | base64 | xargs | sed 's/ //g')
 IPv4=$(echo -ne "$IPv4" | base64 | xargs | sed 's/ //g')

--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -479,7 +479,7 @@ do
 	NICS="$NICS$NIC,$RX,$TX;"
 	# Individual NIC IP addresses
 	IPv4="$IPv4$NIC,$(ip -4 addr show "$NIC" | grep -oP 'inet \K[\d.]+' | xargs | sed 's/ /,/g')"
-	IPv6="$IPv6$NIC,$(ip -6 addr show "ens3" | grep -oP 'inet6 .* scope global' | awk '{print $2}' | xargs | sed 's/ /,/g')"
+	IPv6="$IPv6$NIC,$(ip -6 addr show "$NIC" | grep -oP 'inet6 .* scope global' | awk '{print $2}' | xargs | sed 's/ /,/g')"
 done
 NICS=$(echo -ne "$NICS" | base64 | xargs | sed 's/ //g')
 IPv4=$(echo -ne "$IPv4" | base64 | xargs | sed 's/ //g')


### PR DESCRIPTION
Hello, I've updated the script to use the ip command instead of ifconfig. ifconfig is mostly deprecated these days and is not included in the default installations of many Linux distributions. On the other hand, the ip command is commonly found in default installations