### PR TITLE
2.0.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Documentation available here: https://docs.hetrixtools.com/category/server-monit
 
 -= ChangeLog =-
 
+Version 2.0.9: 
+- Fixed a bug where in some cases RAID would not be detected properly.
+
 Version 2.0.8: 
 - Added support for Custom Variables: https://docs.hetrixtools.com/server-agent-custom-variables/ 
 - Fixed `needs-restarting` for CloudLinux 8 https://github.com/hetrixtools/agent/commit/7e87b191bab90f682d2f55cc0f2650b5f4f7e0c7 (thanks to @JLHC)

--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -24,7 +24,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ScriptPath=$(dirname "${BASH_SOURCE[0]}")
 
 # Agent Version (do not change)
-Version="2.0.9"
+Version="2.0.10"
 
 # Load configuration file
 if [ -f "$ScriptPath"/hetrixtools.cfg ]
@@ -205,7 +205,12 @@ do
 	# RAM swap usage
 	aRAMSwap=$(echo "$VMSTAT" | awk '{print $3}')
 	cRAM=$(echo "$zRAM" | grep "^SwapTotal:" /proc/meminfo | awk '{print $2}')
-	RAMSwap=$(echo | awk "{print $aRAMSwap * 100 / $cRAM}")
+	if [ "$cRAM" -gt 0 ]
+	then
+		RAMSwap=$(echo | awk "{print $aRAMSwap * 100 / $cRAM}")
+	else
+		RAMSwap=0
+	fi
 	tRAMSwap=$(echo | awk "{print $tRAMSwap + $RAMSwap}")
 	
 	# RAM buffers usage

--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -24,7 +24,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ScriptPath=$(dirname "${BASH_SOURCE[0]}")
 
 # Agent Version (do not change)
-Version="2.0.8"
+Version="2.0.9"
 
 # Load configuration file
 if [ -f "$ScriptPath"/hetrixtools.cfg ]
@@ -350,7 +350,8 @@ then
 	OS=$(cat /etc/redhat-release)
 
  	# Check if system is CloudLinux release 8 (CL8 will only output "This system is receiving updates from CloudLinux Network server.")
-  	if [[ "$OS" != "CloudLinux release 8."* ]]; then
+  	if [[ "$OS" != "CloudLinux release 8."* ]]
+	then
 		# Check if system requires reboot (Only supported in CentOS/RHEL 7 and later, with yum-utils installed)
 		if timeout -s 9 5 needs-restarting -r | grep -q 'Reboot is required'
 		then
@@ -531,7 +532,7 @@ then
 		mdadm=$(mdadm -D "$i")
 		if [ -n "$mdadm" ]
 		then
-			mnt=$(timeout 3 df -PB1 | grep "$i" | awk '{print $(NF)}')
+			mnt=$(timeout 3 df -PB1 | grep "$i " | awk '{print $(NF)}')
 			RAID="$RAID$mnt,$i,$mdadm;"
 		fi
 	done


### PR DESCRIPTION
Fixed `division by zero` error for servers without swap.
Replace `ifconfig` with `ip` command for IP address extraction. (thanks to @Ry3nlNaToR)