### PR TITLE
Write log to tmpfs when avaliable

### DIFF
--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -651,8 +651,22 @@ json='{"version":"'"$Version"'","SID":"'"$SID"'","agent":"0","user":"'"$User"'",
 # Compress payload
 jsoncomp=$(echo -ne "$json" | gzip -cf | base64 -w 0 | sed 's/ //g' | sed 's/\//%2F/g' | sed 's/+/%2B/g')
 
+# Set hetrixtools path
+HetrixAgentLogPath="$ScriptPath/hetrixtools_agent.log"
+# Get data path
+if [ -d "/run" ]
+then
+	# On newer Linux, tmpfs is mounted at /run
+	HetrixAgentLogPath="/run/hetrixtools_agent.log"
+elif [ -d "/var/run" ]
+then
+  # On older Linux, tmpfs is mounted at /var/run
+	HetrixAgentLogPath="/var/run/hetrixtools_agent.log"
+fi
+# The default path /run/hetrixtools_agent.log will be used if both /run and /var/run are missing
+
 # Save data to file
-echo "j=$jsoncomp" > "$ScriptPath"/hetrixtools_agent.log
+echo "j=$jsoncomp" > $HetrixAgentLogPath
 
 # Post data
-wget --retry-connrefused --waitretry=1 -t 3 -T 15 -qO- --post-file="$ScriptPath/hetrixtools_agent.log" "$SecuredConnection" https://sm.hetrixtools.net/v2/ &> /dev/null
+wget --retry-connrefused --waitretry=1 -t 3 -T 15 -qO- --post-file="$HetrixAgentLogPath" "$SecuredConnection" https://sm.hetrixtools.net/v2/ &> /dev/null


### PR DESCRIPTION
The PR addresses #57.

The log will be written to `/run/hetrixtools_agent.log` if `/run` is present.
If `/run` doesn't exist while `/var/run` does, the log will be written to `/var/run/hetrixtools_agent.log`.
Only when both `/run` and `/var/run` are absent will the log be written to `$ScriptPath/hetrixtools_agent.log`.
