### PR TITLE
Fix README link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Documentation available here: https://docs.hetrixtools.com/category/server-monitor/
 
-
 ### Changelog
 
 #### Version 2.3.0:


### PR DESCRIPTION
## Summary
- keep the HetrixTools URL on one line
- remove the extra blank line beneath the link
- ensure README ends with a newline

## Testing
- `tail -n 2 README.md`