### PR TITLE
Fix indentation for kill command

### DIFF
--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -152,7 +152,7 @@ if [ "$DEBUG" -eq 1 ]; then echo -e "$ScriptStartTime-$(date +%T]) Found $HTProc
 if [ "$HTProcesses" -ge 50 ]
 then
 	if [ "$DEBUG" -eq 1 ]; then echo -e "$ScriptStartTime-$(date +%T]) Killing $HTProcesses lingering agent processes" >> "$ScriptPath"/debug.log; fi
-	pgrep -f hetrixtools_agent.sh | xargs kill -9
+	pgrep -f hetrixtools_agent.sh | xargs -r kill -9
 fi
 if [ "$HTProcesses" -ge 10 ]
 then

--- a/hetrixtools_install.sh
+++ b/hetrixtools_install.sh
@@ -133,7 +133,7 @@ echo "... done."
 
 # Killing any running hetrixtools agents
 echo "Making sure no hetrixtools agent scripts are currently running..."
-ps aux | grep -ie hetrixtools_agent.sh | awk '{print $2}' | xargs kill -9
+ps aux | grep -ie hetrixtools_agent.sh | awk '{print $2}' | xargs -r kill -9
 echo "... done."
 
 # Checking if hetrixtools user exists

--- a/hetrixtools_uninstall.sh
+++ b/hetrixtools_uninstall.sh
@@ -45,7 +45,7 @@ echo "... done."
 
 # Killing any running hetrixtools agents
 echo "Killing any hetrixtools agent scripts that may be currently running..."
-ps aux | grep -ie hetrixtools_agent.sh | awk '{print $2}' | xargs kill -9
+ps aux | grep -ie hetrixtools_agent.sh | awk '{print $2}' | xargs -r kill -9
 echo "... done."
 
 # Checking if hetrixtools user exists

--- a/hetrixtools_update.sh
+++ b/hetrixtools_update.sh
@@ -218,7 +218,7 @@ fi
 
 # Killing any running hetrixtools agents
 echo "Making sure no hetrixtools agent scripts are currently running..."
-ps aux | grep -ie hetrixtools_agent.sh | awk '{print $2}' | xargs kill -9
+ps aux | grep -ie hetrixtools_agent.sh | awk '{print $2}' | xargs -r kill -9
 echo "... done."
 
 # Assign permissions


### PR DESCRIPTION
## Summary
- keep original tab indentation before the kill command

## Testing
- `bash -n hetrixtools_install.sh`
- `bash -n hetrixtools_uninstall.sh`
- `bash -n hetrixtools_update.sh`
- `bash -n hetrixtools_agent.sh`
- `shellcheck hetrixtools_agent.sh` *(fails: command not found)*