### PR TITLE
Fix NIC detection to skip slaves

### DIFF
--- a/hetrixtools_agent.sh
+++ b/hetrixtools_agent.sh
@@ -196,7 +196,7 @@ then
 else
 	# Automatically detect the network interfaces
 	NetworkInterfacesArray=()
-	while IFS='' read -r line; do NetworkInterfacesArray+=("$line"); done < <(ip a | grep BROADCAST | grep 'state UP' | awk '{print $2}' | awk -F ":" '{print $1}' | awk -F "@" '{print $1}')
+	while IFS='' read -r line; do NetworkInterfacesArray+=("$line"); done < <(ip a | grep BROADCAST | grep 'state UP' | grep -v ' master ' | awk '{print $2}' | awk -F ":" '{print $1}' | awk -F "@" '{print $1}')
 fi
 if [ "$DEBUG" -eq 1 ]; then echo -e "$ScriptStartTime-$(date +%T]) Network Interfaces: ${NetworkInterfacesArray[*]}" >> "$ScriptPath"/debug.log; fi
 


### PR DESCRIPTION
## Summary
- avoid counting traffic on slave interfaces by filtering out interfaces with a master

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684d5c793f488327abe0a0ca4acc9d5b